### PR TITLE
Fix code scanning alert no. 8: Database query built from user-controlled sources

### DIFF
--- a/server.js
+++ b/server.js
@@ -132,7 +132,7 @@ app.put('/api/products/:productCode/quantity', async (req, res) => {
       // 更新指定產品的数量
       const updatedProduct = await Product.findOneAndUpdate(
           { 商品編號: productCode },
-          { 數量 },
+          { 數量: { $eq: 數量 } },
           { new: true }
       );
 


### PR DESCRIPTION
Fixes [https://github.com/ed0910439/inventory-server/security/code-scanning/8](https://github.com/ed0910439/inventory-server/security/code-scanning/8)

To fix the problem, we need to ensure that the user-provided value `數量` is properly sanitized or validated before being used in the MongoDB query. The best way to fix this is to use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
